### PR TITLE
Removed dependency score from regression adjustment

### DIFF
--- a/prelim-demo.ipynb
+++ b/prelim-demo.ipynb
@@ -177,7 +177,7 @@
    "outputs": [],
    "source": [
     "## fit multivariate logistic regression for covariate adjustment\n",
-    "fit1 <- glm(enter ~ treated +gender + age + depscore + intquit + \n",
+    "fit1 <- glm(enter ~ treated +gender + age + intquit + \n",
     "           determquit + livesmoke + imd + prev,\n",
     "          family = binomial,\n",
     "          data)"


### PR DESCRIPTION
We removed the dependency score from the logistic regression adjustment because of X, Y, and Z